### PR TITLE
Fix/invalid license error

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ In Build Settings for your project including this library, please change Build S
 Bitcode Enabled: false
 Valid Architectures: arm64
 
+In `General`, add `ScandyCore.framework` to `Frameworks, Libraries and Embedded Content`.
+
 ## Contributing
 
 See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the repository and the development workflow.

--- a/ios/RCTScandyCoreManager.mm
+++ b/ios/RCTScandyCoreManager.mm
@@ -119,13 +119,18 @@ RCT_EXPORT_METHOD(initializeScanner
   dispatch_async(dispatch_get_main_queue(), ^{
     auto slam_config =
       ScandyCoreManager.scandyCorePtr->getIScandyCoreConfiguration();
-    [self initializeScanner];
-    bool inited = scandy::core::ScanState::INITIALIZED ==
-                  ScandyCoreManager.scandyCorePtr->getScanState();
-    if (inited) {
-      return resolve(nil);
+    auto licenseStatus = [ScandyCore setLicense];
+    if (licenseStatus == scandy::core::Status::SUCCESS){
+      [self initializeScanner];
+      bool inited = scandy::core::ScanState::INITIALIZED ==
+                    ScandyCoreManager.scandyCorePtr->getScanState();
+      if (inited) {
+        return resolve(nil);
+      } else {
+        return reject(@"-1", @"Could not initialize scanner", nil);
+      }
     } else {
-      return reject(@"-1", @"Could not initialize scanner", nil);
+      return reject(@"-1", @"Invalid license", nil);
     }
   });
 }


### PR DESCRIPTION
Changes:
- Adds instructions in `README.md` to add ScandyCore.framework to `Frameworks, Libraries and Embedded Content`
- If scanner fails to initialize due to invalid license, outputs `Invalid license` - previously outputted vague `Could not initialize scanner` message