### PR TITLE
Fix toggleV2Scanning Error

### DIFF
--- a/ios/RCTScandyCoreManager.mm
+++ b/ios/RCTScandyCoreManager.mm
@@ -357,12 +357,12 @@ RCT_EXPORT_METHOD(toggleV2Scanning
     
     // get the current scan state so we can reset it after toggling
     auto scanState = ScandyCoreManager.scandyCorePtr->getScanState();
-    const bool wasInited = scanState == scandy::core::ScanState::INITIALIZED;
     const bool wasPreviewing = scanState == scandy::core::ScanState::PREVIEWING ||
                          scanState == scandy::core::ScanState::SCANNING;
+    const bool wasInited = wasPreviewing || scanState == scandy::core::ScanState::INITIALIZED;
     
     // Unitialized the scanner if we need to
-    if (wasInited || wasPreviewing) {
+    if (wasInited) {
       [ScandyCore uninitializeScanner];
     }
     
@@ -376,7 +376,6 @@ RCT_EXPORT_METHOD(toggleV2Scanning
 
     // Start the preview if it was before toggling
     if (wasPreviewing) {
-      [ScandyCore initializeScanner];
       [ScandyCore startPreview];
     }
 

--- a/ios/RCTScandyCoreManager.mm
+++ b/ios/RCTScandyCoreManager.mm
@@ -362,7 +362,7 @@ RCT_EXPORT_METHOD(toggleV2Scanning
                          scanState == scandy::core::ScanState::SCANNING;
     
     // Unitialized the scanner if we need to
-    if (wasInited) {
+    if (wasInited || wasPreviewing) {
       [ScandyCore uninitializeScanner];
     }
     
@@ -376,6 +376,7 @@ RCT_EXPORT_METHOD(toggleV2Scanning
 
     // Start the preview if it was before toggling
     if (wasPreviewing) {
+      [ScandyCore initializeScanner];
       [ScandyCore startPreview];
     }
 


### PR DESCRIPTION
When scanner is initialized and toggleV2Scanning is called, a `Invalid state` error is thrown. 

Fix:
- if scanner is previewing, we need to uninitialize before toggling and reinitialize after toggling