### PR TITLE
Clean sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ const result = await Roux.startPreview();
 // ...
 // Update the scan parameters
 
+// Toggle v2 scanning
+await Roux.toggleV2Scanning();
+
+// Get v2 scanning (returns true/false)
+const v2 = await Roux.getV2ScanningEnabled();
+
 // For V1 (aka bounded scanning)
 const boxSize = 1.5; // meters
 const result = await Roux.setSize(boxSize);

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ import { RouxView } from 'react-native-roux-sdk';
   onVisualizerReady={() =>
     console.log('wait for this to fire, then setup the scan preview')
   }
-  onPreviewStart={this._onScannerStart}
+  onPreviewStart={this._onPreviewStart}
   onScannerStart={this._onScannerStart}
   onScannerStop={this._onScannerStop}
   onGenerateMesh={this._onGenerateMesh}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install https://github.com/Scandy-co/react-native-roux-sdk
 ### Methods
 
 ```js
-import { Roux } from 'react-native-roux-sdk';
+import Roux from 'react-native-roux-sdk';
 
 // ...
 // Set up the scan preview

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ import { RouxView } from 'react-native-roux-sdk';
 
 <RouxView
   style={{ flex: 1 }}
+  onScanStateChanged={this._onScanStateChanged}
   onVisualizerReady={() =>
     console.log('wait for this to fire, then setup the scan preview')
   }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ const result = await Roux.setSize(voxelSize * 1e-3); // set size needs meters, s
 // ...
 // Start, stop, and save your model
 const result = await Roux.startScan();
-const result = await Roux.stopScan(); // generates your mesh & shows mesh in preview window
+const result = await Roux.stopScan();
+const result = await Roux.generateMesh();
 const result = await Roux.saveScan(destination);
 ```
 

--- a/example/package.json
+++ b/example/package.json
@@ -9,6 +9,7 @@
     "start": "react-native start"
   },
   "dependencies": {
+    "@react-native-community/slider": "^3.0.0",
     "react": "16.11.0",
     "react-native": "0.62.0",
     "react-native-fs": "^2.16.6",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -2,27 +2,33 @@ import React from 'react';
 import {
   StyleSheet,
   View,
-  Slider,
   Switch,
-  Button,
+  TouchableOpacity,
   Alert,
   Text,
 } from 'react-native';
+import Slider from '@react-native-community/slider';
+
 import Roux, { RouxView } from 'react-native-roux-sdk';
 import RNFS from 'react-native-fs';
 
 export default class App extends React.Component {
   state = {
-    v2ScanningMode: true, // v2 scanning on by default
+    scanState: '',
+    v2ScanningMode: null, //v2ScanningMode defaults to true
     scanSize: 1.0, // scan size in mm or meters pending on scanning mode
   };
   constructor(props: Readonly<{}>) {
     super(props);
   }
 
+  handleScanStateChanged = (scanState) => {
+    console.log('Scan State: ', scanState);
+    this.setState({ scanState });
+  };
+
   setupPreview = async () => {
     try {
-      await Roux.toggleV2Scanning(this.state.v2ScanningMode);
       await Roux.initializeScanner();
       await Roux.startPreview();
     } catch (err) {
@@ -30,19 +36,56 @@ export default class App extends React.Component {
     }
   };
 
-  async onScannerStop() {
+  startScan = async () => {
+    try {
+      await Roux.startScan();
+    } catch (err) {
+      console.warn(err);
+    }
+  };
+
+  stopScan = async () => {
+    try {
+      await Roux.stopScan();
+    } catch (err) {
+      console.warn(err);
+    }
+  };
+
+  onPreviewStart = () => {
+    console.log('Preview Started');
+  };
+
+  onScannerStart = () => {
+    console.log('Scanner Started');
+  };
+
+  onScannerStop = async () => {
     try {
       await Roux.generateMesh();
     } catch (err) {
       console.warn(err);
     }
-  }
+  };
 
-  async onGenerateMesh() {
+  onGenerateMesh = () => {
     // call back that generate mesh finished
-  }
+    console.log('MESH GENERATED');
+  };
 
-  async saveScan() {
+  onSaveMesh = async () => {
+    // call back that generate mesh finished
+    console.log('MESH SAVED');
+    this.restartScanner();
+  };
+
+  restartScanner = async () => {
+    //NOTE: you do not need to call initializeScanner again;
+    // scanner will remain initialized until RouxView unmounts
+    await Roux.startPreview();
+  };
+
+  saveScan = async () => {
     try {
       const dirPath = `${RNFS.DocumentDirectoryPath}/${Date.now()}`;
       await RNFS.mkdir(dirPath);
@@ -53,13 +96,13 @@ export default class App extends React.Component {
     } catch (err) {
       console.warn(err);
     }
-  }
+  };
 
   toggleV2Scanning = async () => {
     try {
-      const v2ScanningMode = !this.state.v2ScanningMode;
-      await Roux.toggleV2Scanning(v2ScanningMode);
-      this.setState({ v2ScanningMode });
+      const v2ScanningMode = await Roux.getV2ScanningEnabled();
+      await Roux.toggleV2Scanning(!v2ScanningMode);
+      this.setState({ v2ScanningMode: !v2ScanningMode });
       this.setSize(this.state.scanSize);
     } catch (err) {
       console.warn(err);
@@ -77,68 +120,70 @@ export default class App extends React.Component {
     }
   };
 
+  async componentDidMount() {
+    //Get default scanning mode and set state
+    const v2ScanningMode = await Roux.getV2ScanningEnabled();
+    this.setState({ v2ScanningMode });
+  }
+
   render() {
+    const { scanState } = this.state;
     return (
       <View style={styles.container}>
         <RouxView
           style={styles.roux}
+          onScanStateChanged={this.handleScanStateChanged}
           onVisualizerReady={this.setupPreview}
+          onPreviewStart={this.onPreviewStart}
+          onScannerStart={this.onScannerStart}
           onScannerStop={this.onScannerStop}
           onGenerateMesh={this.onGenerateMesh}
+          onSaveMesh={this.onSaveMesh}
         />
-        <View style={styles.actions}>
-          <View style={styles.row}>
-            <View style={styles.column}>
-              {this.state.v2ScanningMode ? (
-                <Text>size: {this.state.scanSize}mm</Text>
-              ) : (
-                <Text>size: {this.state.scanSize}m</Text>
-              )}
-
+        {(scanState === 'INITIALIZED' || scanState === 'PREVIEWING') && (
+          <>
+            <TouchableOpacity onPress={this.startScan} style={styles.button}>
+              <Text style={styles.buttonText}>START</Text>
+            </TouchableOpacity>
+            <View style={styles.sliderContainer}>
               <Slider
                 minimumValue={0.2}
                 maximumValue={4}
-                style={styles.slider}
                 onValueChange={this.setSize}
+                style={styles.slider}
               />
+              <Text style={styles.previewLabel}>
+                size: {this.state.scanSize}
+                {this.state.v2ScanningMode ? 'mm' : 'm'}
+              </Text>
             </View>
-          </View>
-          <View style={styles.row}>
-            <View style={styles.column}>
+            <View style={styles.v2SwitchContainer}>
               <Switch
                 onValueChange={this.toggleV2Scanning}
                 value={this.state.v2ScanningMode}
               />
-              <Text>v2 scanning</Text>
+              <Text style={styles.previewLabel}>v2 scanning</Text>
             </View>
-            <View style={styles.column}>
-              <Switch />
-            </View>
-            <View style={styles.column}>
-              <Switch />
-            </View>
-          </View>
-          <View style={styles.row}>
-            <Button
-              title="start scan"
-              onPress={() => {
-                Roux.startScan();
-              }}
-            />
-            <Button
-              title="stop scan"
-              onPress={() => {
-                Roux.stopScan();
-              }}
-            />
-            <Button
-              title="save scan"
-              onPress={() => {
-                this.saveScan();
-              }}
-            />
-          </View>
-        </View>
+          </>
+        )}
+        {scanState === 'SCANNING' && (
+          <TouchableOpacity onPress={this.stopScan} style={styles.button}>
+            <Text style={styles.buttonText}>STOP</Text>
+          </TouchableOpacity>
+        )}
+        {scanState === 'VIEWING' && (
+          <>
+            <TouchableOpacity onPress={this.saveScan} style={styles.button}>
+              <Text style={styles.buttonText}>SAVE</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={this.restartScanner}
+              style={styles.newScanButton}
+            >
+              <Text style={styles.buttonText}>NEW SCAN</Text>
+            </TouchableOpacity>
+          </>
+        )}
       </View>
     );
   }
@@ -148,9 +193,47 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  button: {
+    position: 'absolute',
+    alignSelf: 'center',
+    justifyContent: 'center',
+    alignItems: 'center',
+    bottom: 150,
+    width: 150,
+    height: 70,
+    backgroundColor: '#f2494a',
+  },
+  newScanButton: {
+    position: 'absolute',
+    alignSelf: 'center',
+    justifyContent: 'center',
+    alignItems: 'center',
+    bottom: 70,
+    width: 150,
+    height: 70,
+    backgroundColor: '#586168',
+  },
+  buttonText: {
+    fontSize: 24,
+    color: 'white',
+  },
+  // actions: { backgroundColor: "transparent" },
+  sliderContainer: {
+    position: 'absolute',
+    bottom: 70,
+    width: '80%',
+    alignSelf: 'center',
+  },
+  previewLabel: {
+    color: 'white',
+    alignSelf: 'center',
+    fontSize: 20,
+  },
+  v2SwitchContainer: {
+    position: 'absolute',
+    alignItems: 'center',
+    top: 100,
+    right: 10,
+  },
   roux: { flex: 1, backgroundColor: 'blue' },
-  actions: { flex: 1, backgroundColor: 'white', padding: 16 },
-  slider: { flex: 1 },
-  row: { flex: 1, flexDirection: 'row', justifyContent: 'space-between' },
-  column: { flex: 1, flexDirection: 'column', justifyContent: 'space-between' },
 });

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -867,6 +867,11 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
+"@react-native-community/slider@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-3.0.0.tgz#ffbf78689fc0572fb5c1e2ccb61b2ef074d3dcd2"
+  integrity sha512-deNc3JHBHz24YN+0DTAocXfrYFIFc1DvsIriMJSsJlR/MvsLzoq2+qwaEN+0/LJ37pstv85wZWY0pNugk4e41g==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"

--- a/ios/RCTScandyCoreManager.mm
+++ b/ios/RCTScandyCoreManager.mm
@@ -283,8 +283,7 @@ RCT_EXPORT_METHOD(startScan
     if (startStatus == scandy::core::Status::SUCCESS) {
       return resolve(nil);
     } else {
-      auto reason = [NSString stringWithUTF8String:getStatusStr(startStatus)];
-      return reject(reason, reason, nil);
+      return reject([self formatStatusError:startStatus], [self formatStatusError:startStatus], nil);
     }
   });
 }

--- a/ios/RCTScandyCoreManager.mm
+++ b/ios/RCTScandyCoreManager.mm
@@ -535,7 +535,15 @@ RCT_EXPORT_METHOD(getCurrentScanState
 
 - (NSString*)formatScanStateToString:(scandy::core::ScanState)scanState
 {
-  return [NSString stringWithFormat:@"%s", scandy::core::getScanStateString(scanState).c_str()];
+    NSString* scanStateStr = [NSString stringWithFormat:@"%s", scandy::core::getScanStateString(scanState).c_str()];
+    if ([scanStateStr rangeOfString:@"scandy::core::ScanState"].location == NSNotFound){
+        return scanStateStr;
+    } else {
+        auto start = [scanStateStr rangeOfString:@":" options:NSBackwardsSearch].location + 3;
+        auto length = scanStateStr.length - start - 1;
+        NSRange substrRange = NSMakeRange(start, length);
+        return [scanStateStr substringWithRange:substrRange];
+    }
 }
 
 - (NSString*)formatStatusError:(scandy::core::Status)status

--- a/ios/RCTScandyCoreManager.mm
+++ b/ios/RCTScandyCoreManager.mm
@@ -347,8 +347,7 @@ RCT_EXPORT_METHOD(getV2ScanningEnabled
       ScandyCoreManager.scandyCorePtr->getIScandyCoreConfiguration()
         ->m_use_unbounded;
     NSNumber* v2 = [NSNumber numberWithBool:unbounded];
-    NSNumber* v1 = [NSNumber numberWithBool:!unbounded];
-    resolve(@{ @"v2" : v2, @"v1" : v1 });
+    resolve(v2);
   });
 }
 

--- a/ios/RCTScandyCoreView.mm
+++ b/ios/RCTScandyCoreView.mm
@@ -131,6 +131,32 @@ RCT_EXPORT_VIEW_PROPERTY(kind, NSString);
   }
 }
 
+- (void)onSaveMesh:(scandy::core::Status)status
+{
+  //  NSLog(@"onSaveMesh");
+
+  if (self.scanView.onSaveMesh) {
+    self.scanView.onSaveMesh(@{
+      @"success" :
+        [NSNumber numberWithBool:(status == scandy::core::Status::SUCCESS)],
+      @"status" : [self formatStatusError:status]
+    });
+  }
+}
+
+- (void)onGenerateMesh:(scandy::core::Status)status
+{
+  //  NSLog(@"onGenerateMesh");
+
+  if (self.scanView.onGenerateMesh) {
+    self.scanView.onGenerateMesh(@{
+      @"success" :
+        [NSNumber numberWithBool:(status == scandy::core::Status::SUCCESS)],
+      @"status" : [self formatStatusError:status]
+    });
+  }
+}
+
 - (void)onHostDiscovered:(NSString*)host
 {
   //  NSLog(@"onHostDiscovered: %@", host);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -221,6 +221,7 @@ class RouxView extends React.Component<Props> {
 //  but I hit a speedbump...
 type RouxType = {
   initializeScanner(): Promise<any>;
+  uninitializeScanner(): Promise<any>;
   startPreview(): Promise<any>;
   startScan(): Promise<any>;
   stopScan(): Promise<any>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,7 +67,7 @@ class RouxView extends React.Component<Props> {
     onVisualizerReady: () => console.log('ScandyCore: Visualizer Readied'),
     onPreviewStart: () => console.log('ScandyCore: Preview Started'),
     onScannerStart: () => console.log('ScandyCore: Scanner Started'),
-    onScannerStop: () => console.log('ScandyCore: Scanner Stoped'),
+    onScannerStop: () => console.log('ScandyCore: Scanner Stopped'),
     onGenerateMesh: () => console.log('ScandyCore: Generated Mesh'),
     onSaveMesh: () => console.log('ScandyCore: Saved Mesh'),
     onMeshLoaded: () => console.log('Scandy Core: Mesh Loaded'),
@@ -229,6 +229,7 @@ type RouxType = {
   setSize(size: number): Promise<any>;
   loadMesh(dict: object): Promise<any>;
   toggleV2Scanning(enabled: boolean): Promise<any>;
+  getV2ScanningEnabled(): Promise<any>;
 };
 
 // const { RouxSdk } = NativeModules;


### PR DESCRIPTION
Changes:
- getV2ScanningEnabled returns bool instead of string
- fix error message on `startScan()` (previously said "unknown native error")
- `formatScanStateToString()` does some fancy string manipulation footwork to output string that's easier to work with (ie. `PREVIEWING` instead of `scandy::core::ScanState::VIEWING: "VIEWING"`). Later we can update this in `getScanStateString` in Roux SDK, but added this if-else for now to avoid having to put out a new release
- adds definitions for `onSaveMesh` and `onGenerateMesh`
- adds `uninitializeScanner` & `getV2ScanningEnabled` to RouxType
- updates example app based on these changes (same as https://github.com/Scandy-co/RouxReactNativeHelloWorld/pull/3)