### PR TITLE
Add/optimize mesh size

### DIFF
--- a/ios/RCTScandyCoreManager.mm
+++ b/ios/RCTScandyCoreManager.mm
@@ -835,8 +835,9 @@ RCT_EXPORT_METHOD(optimizeMeshSize
             [ScandyCore extractLargestSurface:1.0];
             [ScandyCore applyEditsFromMeshViewport:true];
             
+            NSLog(@"Decimating 0.01");
             //Initial light decimate
-            [ScandyCore decimateMesh:0.2];
+            [ScandyCore decimateMesh:0.01];
             [ScandyCore applyEditsFromMeshViewport:true];
         }
 
@@ -844,9 +845,12 @@ RCT_EXPORT_METHOD(optimizeMeshSize
         mesh_size = ScandyCoreManager.scandyCorePtr->getMeshMemorySize();
         NSLog(@"Post-initial clean mesh size: %fMB", mesh_size);
         while(mesh_size > max_size && status == ScandyCoreStatus::SUCCESS){
-            NSLog(@"Mesh is > 24MB(%fMB). Decimating 60 percent...", mesh_size);
-            status = [ScandyCore decimateMesh:0.6];
-            status = [ScandyCore applyEditsFromMeshViewport:true];
+            auto decimate_estimate = (max_size/mesh_size) * 1.05;
+            decimate_estimate = fmin(decimate_estimate, 0.6);
+            decimate_estimate = fmax(decimate_estimate, 0.05);
+            NSLog(@"Mesh is > 24MB(%fMB). Decimating %f...", mesh_size, decimate_estimate);
+            status = [ScandyCore decimateMesh:decimate_estimate];
+            [ScandyCore applyEditsFromMeshViewport:true];
             mesh_size = ScandyCoreManager.scandyCorePtr->getMeshMemorySize();
         }
         

--- a/ios/RCTScandyCoreManager.mm
+++ b/ios/RCTScandyCoreManager.mm
@@ -845,7 +845,7 @@ RCT_EXPORT_METHOD(optimizeMeshSize
         mesh_size = ScandyCoreManager.scandyCorePtr->getMeshMemorySize();
         NSLog(@"Post-initial clean mesh size: %fMB", mesh_size);
         while(mesh_size > max_size && status == ScandyCoreStatus::SUCCESS){
-            auto decimate_estimate = (max_size/mesh_size) * 1.05;
+            auto decimate_estimate = 1 - (max_size/mesh_size);
             decimate_estimate = fmin(decimate_estimate, 0.6);
             decimate_estimate = fmax(decimate_estimate, 0.05);
             NSLog(@"Mesh is > 24MB(%fMB). Decimating %f...", mesh_size, decimate_estimate);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -264,6 +264,7 @@ type RouxType = {
   extractLargestSurface(min_percent: number): Promise<any>;
   makeWaterTight(depth: number): Promise<any>;
   applyEditsFromMeshViewport(apply_changes: boolean): Promise<any>;
+  optimizeMeshSize(max_size: number): Promise<any>;
 };
 
 // const { RouxSdk } = NativeModules;


### PR DESCRIPTION
Adds `optimizeMeshSize` function which accepts a `max_size` (in MB) parameter:
- Checks mesh size
- If mesh_size > max_size, runs `extractLargestSurface:1.0` and `decimateMesh:0.2`
- Checks mesh_size again
- If mesh_size > max_size, runs `decimateMesh:0.6` until the mesh_size < max_size

- returns object containing the new mesh size